### PR TITLE
support to put links along with objects

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,33 @@ Clojure bindings to the [Riak](http://www.basho.com/Riak.html) [Protocol Buffers
 
 For an introduction to the library, see the blog post [Exploring Riak with Clojure](http://mmcgrana.github.com/2010/08/riak-clojure.html)
 
+## Differences in this fork
+
+Support for links
+    
+    ;; an example put fn
+    (defn put [bucket key data]
+      (let [links (or (:links (meta data)) '())
+            data {:value (.getBytes (json/json-str data))
+                  :content-type "application/json"
+                  :links links}]
+
+        (riak/put riak-client
+                  bucket
+                  key
+                  data)))
+        
+    (put "test-bucket" "test-key"
+         (with-meta {:a 1} {:links '({:bucket "foo"
+                                      :key "bar"
+                                      :tag "foobar"})}))
+
+## TODO
+
+In my personal projects there are a great deal of helper functions to
+make storing links / objects / etc significantly shorter than in the
+example above. I should try to roll them into this code.
+
 ## License
 
 Released under the MIT License: <http://www.opensource.org/licenses/mit-license.php>

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Clojure bindings to the [Riak](http://www.basho.com/Riak.html) [Protocol Buffers
 `clj-riak` is available as a Maven artifact from [Clojars](http://clojars.org/clj-riak):
 
     :dependencies
-      [[clj-riak "0.1.0-SNAPSHOT"] ...]
+      [[org.clojars.ossareh/clj-riak "0.1.0-SNAPSHOT"] ...]
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,10 @@
 (defproject clj-riak "0.1.0-SNAPSHOT"
-  :description
-    "Clojure bindings to the Riak Protocol Buffers API."
-  :dependencies
-   [[org.clojure/clojure "1.2.0-RC2"]
-    [org.clojure/clojure-contrib "1.2.0-RC2"]
-    [org.clojars.mmcgrana/riak-java-pb-client "0.1.0-SNAPSHOT"]])
+  :description "Clojure bindings to the Riak Protocol Buffers API."
+
+  :repositories [["clojars" "http://clojars.org/repo"]]
+  
+  :dependencies [[org.clojure/clojure "1.2.0"]
+                 [org.clojure/clojure-contrib "1.2.0"]
+                 [org.clojars.mmcgrana/riak-java-pb-client "0.1.0-SNAPSHOT"]]
+
+  :dev-dependencies [[lein-clojars "0.6.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject clj-riak "0.1.0-SNAPSHOT"
+(defproject org.clojars.ossareh/clj-riak "0.1.0-SNAPSHOT"
   :description "Clojure bindings to the Riak Protocol Buffers API."
 
-  :repositories [["clojars" "http://clojars.org/repo"]]
+  :repositories {"clojars" "http://clojars.org/repo"}
   
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/clojure-contrib "1.2.0"]


### PR DESCRIPTION
you can now:

```
(put rc "test" "t1" {:value (.getBytes (json/json-str {:a 1 :b 2}))
                          :content-type "application/json"
                          :links {:bucket "test" :key "t2" :tag "foo"})
```

:links can be a {} or a vector of maps.
